### PR TITLE
Update scaling TE-14.3 and TE-14.4 DUT setup with more physical output ports

### DIFF
--- a/feature/gribi/otg_tests/gribi_full_scale_t1/README.md
+++ b/feature/gribi/otg_tests/gribi_full_scale_t1/README.md
@@ -10,8 +10,19 @@ Use the same topology as TE-14.2 but in increased scale:
 
 - DUT [port1] <-> ATE [port1]
 - DUT [port2] <-> ATE [port2]
+- DUT [port3] <-> ATE [port3]
+- DUT [port4] <-> ATE [port4]
+- DUT [port5] <-> ATE [port5]
+- DUT [port6] <-> ATE [port6]
+- DUT [port7] <-> ATE [port7]
+- DUT [port8] <-> ATE [port8]
+- DUT [port9] <-> ATE [port9]
 - DUT [port1] -> 1 L3 sub-interface <-> ATE [port1] 1 L3 sub-interface , subnet `192.0.2.0/30`
-- DUT [port2] -> 640 L3 sub-interfaces <-> ATE [port2] 640 L3 sub-interfaces, Use Vlan tagging for differentiation - `198.18.0.0/20` subdivided into `/30` chunks
+
+Each of the 8 port pairs (DUT/ATE [port2] through [port9]) is configured with 80 L3 sub-interfaces.
+This provides a total of 8 * 80 = 640 L3 sub-interfaces.
+VLAN tagging is used to differentiate the sub-interfaces on each physical port.
+The IP address range 198.18.0.0/20 is subdivided into /30 chunks, which are distributed across these 640 sub-interfaces.
 
 ## Variables
 ```

--- a/feature/gribi/otg_tests/gribi_full_scale_t1/README.md
+++ b/feature/gribi/otg_tests/gribi_full_scale_t1/README.md
@@ -16,11 +16,10 @@ Use the same topology as TE-14.2 but in increased scale:
 - DUT [port6] <-> ATE [port6]
 - DUT [port7] <-> ATE [port7]
 - DUT [port8] <-> ATE [port8]
-- DUT [port9] <-> ATE [port9]
 - DUT [port1] -> 1 L3 sub-interface <-> ATE [port1] 1 L3 sub-interface , subnet `192.0.2.0/30`
 
-Each of the 8 port pairs (DUT/ATE [port2] through [port9]) is configured with 80 L3 sub-interfaces.
-This provides a total of 8 * 80 = 640 L3 sub-interfaces.
+Each of the 8 port pairs (DUT/ATE [port2] through [port7]) is configured with 90 L3 sub-interfaces, and [port8] - with 100 L3 sub-interfaces.
+This provides a total of 640 L3 sub-interfaces.
 VLAN tagging is used to differentiate the sub-interfaces on each physical port.
 The IP address range 198.18.0.0/20 is subdivided into /30 chunks, which are distributed across these 640 sub-interfaces.
 

--- a/feature/gribi/otg_tests/gribi_full_scale_t1/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_full_scale_t1/metadata.textproto
@@ -4,4 +4,4 @@
 uuid: "e1888c8a-eaed-4496-88a2-9af7ffc32c49"
 plan_id: "TE-14.3"
 description: "gRIBI Scaling - full scale setup, target T1"
-testbed: TESTBED_DUT_ATE_2LINKS
+testbed: TESTBED_DUT_ATE_8LINKS

--- a/feature/gribi/otg_tests/gribi_full_scale_t2/metadata.textproto
+++ b/feature/gribi/otg_tests/gribi_full_scale_t2/metadata.textproto
@@ -4,4 +4,4 @@
 uuid: "401ea8f3-3aaa-4c98-919e-77f61de4e550"
 plan_id: "TE-14.4"
 description: "gRIBI Scaling - full scale setup, target T2"
-testbed: TESTBED_DUT_ATE_2LINKS
+testbed: TESTBED_DUT_ATE_8LINKS


### PR DESCRIPTION
Instead of having one physical output port with 640 sub-interfaces, we shall have 7:

Concentrating a large number of sub-interfaces (e.g., 640) on a single physical port overloads the port's resources, causing the device to become unresponsive. This configuration does not reflect production environments, where logical interfaces are spread across numerous physical interfaces.

Using multiple physical ports (e.g., 7 ports with 91 sub-interfaces each) provides a more realistic test scenario, reduces the load on any single port, and ensures that test failures are due to actual feature issues rather than artificial hardware limitations. This change aims to improve test reliability and better mimic production network behavior.